### PR TITLE
Removed deprecated variable openshift_node_kubelet_args

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -22,7 +22,7 @@ containerized=True
 os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 openshift_disable_check=disk_availability,docker_storage,memory_availability,docker_image_availability
 
-openshift_node_kubelet_args={'pods-per-core': ['10']}
+
 
 deployment_type=openshift-enterprise
 openshift_deployment_type=openshift-enterprise


### PR DESCRIPTION
Removed deprecated variable openshift_node_kubelet_args

* Replaced variable removed

last_checked_var: openshift_master_identity_providers;Found removed variables: openshift_node_kubelet_args is replaced by openshift_node_groups[<item>].edits;

Since the install fails on the above and the inventory.ini file is downloaded every time from the configured repo I had to fork and commit this.
without the node_groups, it will all back to the default.